### PR TITLE
v1.0.1.5 Get anyone's tournament w/o subdomain

### DIFF
--- a/ChallongeApiWrapper/ChallongePortal.cs
+++ b/ChallongeApiWrapper/ChallongePortal.cs
@@ -43,8 +43,9 @@ namespace Fizzi.Libraries.ChallongeApiWrapper
             return response.Data;
         }
 
-        public Tournament ShowTournament(int tournamentId)
+        public Tournament ShowTournament(String tournamentId)
         {
+            if (!string.IsNullOrEmpty(Subdomain)) { tournamentId = Subdomain + "-" + tournamentId; }
             var request = new RestRequest(string.Format("tournaments/{0}.xml", tournamentId), Method.GET);
             request.AddParameter("api_key", ApiKey);
 

--- a/ChallongeApiWrapper/Tournament.cs
+++ b/ChallongeApiWrapper/Tournament.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Fizzi.Libraries.ChallongeApiWrapper
 {
-    public class Tournament
+    public class Tournament : IEquatable<Tournament>
     {
         public DateTime? CreatedAt { get; set; }
         public DateTime? StartedAt { get; set; }
@@ -24,5 +24,13 @@ namespace Fizzi.Libraries.ChallongeApiWrapper
         public string Url { get; set; }
         public string FullChallongeUrl { get; set; }
         public string LiveImageUrl { get; set; }
+
+        public bool Equals(Tournament other)
+        {
+            if (this.FullChallongeUrl == other.FullChallongeUrl)
+                return true;
+            else
+                return false;
+        }
     }
 }

--- a/SkillKeeper/SKChallongeLoader.Designer.cs
+++ b/SkillKeeper/SKChallongeLoader.Designer.cs
@@ -35,12 +35,14 @@
             this.apiKeyBox = new System.Windows.Forms.TextBox();
             this.authButton = new System.Windows.Forms.Button();
             this.cancelButton = new System.Windows.Forms.Button();
+            this.tournamentNameBox = new System.Windows.Forms.TextBox();
+            this.tournamentLabel = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 39);
+            this.label1.Location = new System.Drawing.Point(12, 21);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(45, 13);
             this.label1.TabIndex = 0;
@@ -49,7 +51,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(12, 73);
+            this.label2.Location = new System.Drawing.Point(12, 47);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(60, 13);
             this.label2.TabIndex = 1;
@@ -57,14 +59,14 @@
             // 
             // subDomainBox
             // 
-            this.subDomainBox.Location = new System.Drawing.Point(78, 70);
+            this.subDomainBox.Location = new System.Drawing.Point(78, 44);
             this.subDomainBox.Name = "subDomainBox";
             this.subDomainBox.Size = new System.Drawing.Size(415, 20);
             this.subDomainBox.TabIndex = 2;
             // 
             // apiKeyBox
             // 
-            this.apiKeyBox.Location = new System.Drawing.Point(78, 36);
+            this.apiKeyBox.Location = new System.Drawing.Point(78, 18);
             this.apiKeyBox.Name = "apiKeyBox";
             this.apiKeyBox.Size = new System.Drawing.Size(415, 20);
             this.apiKeyBox.TabIndex = 1;
@@ -74,10 +76,10 @@
             // 
             this.authButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.authButton.Enabled = false;
-            this.authButton.Location = new System.Drawing.Point(410, 96);
+            this.authButton.Location = new System.Drawing.Point(321, 96);
             this.authButton.Name = "authButton";
             this.authButton.Size = new System.Drawing.Size(83, 23);
-            this.authButton.TabIndex = 3;
+            this.authButton.TabIndex = 4;
             this.authButton.Text = "Authenticate";
             this.authButton.UseVisualStyleBackColor = true;
             this.authButton.Click += new System.EventHandler(this.authButton_Click);
@@ -85,19 +87,37 @@
             // cancelButton
             // 
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(410, 125);
+            this.cancelButton.Location = new System.Drawing.Point(410, 96);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(83, 23);
-            this.cancelButton.TabIndex = 4;
+            this.cancelButton.TabIndex = 5;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
             this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
+            // 
+            // tournamentNameBox
+            // 
+            this.tournamentNameBox.Location = new System.Drawing.Point(78, 70);
+            this.tournamentNameBox.Name = "tournamentNameBox";
+            this.tournamentNameBox.Size = new System.Drawing.Size(415, 20);
+            this.tournamentNameBox.TabIndex = 3;
+            // 
+            // tournamentLabel
+            // 
+            this.tournamentLabel.AutoSize = true;
+            this.tournamentLabel.Location = new System.Drawing.Point(12, 73);
+            this.tournamentLabel.Name = "tournamentLabel";
+            this.tournamentLabel.Size = new System.Drawing.Size(64, 13);
+            this.tournamentLabel.TabIndex = 6;
+            this.tournamentLabel.Text = "Tournament";
             // 
             // SKChallongeLoader
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(505, 160);
+            this.ClientSize = new System.Drawing.Size(505, 134);
+            this.Controls.Add(this.tournamentLabel);
+            this.Controls.Add(this.tournamentNameBox);
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.authButton);
             this.Controls.Add(this.apiKeyBox);
@@ -122,5 +142,7 @@
         private System.Windows.Forms.TextBox apiKeyBox;
         private System.Windows.Forms.Button authButton;
         private System.Windows.Forms.Button cancelButton;
+        private System.Windows.Forms.TextBox tournamentNameBox;
+        private System.Windows.Forms.Label tournamentLabel;
     }
 }

--- a/SkillKeeper/SKChallongeLoader.cs
+++ b/SkillKeeper/SKChallongeLoader.cs
@@ -14,6 +14,7 @@ namespace SkillKeeper
     {
         private static string apiKey = string.Empty;
         private static string subdomain = string.Empty;
+        private static string tournamentName = string.Empty;
 
         public SKChallongeLoader()
         {
@@ -25,6 +26,7 @@ namespace SkillKeeper
             //Load apikey and subdomain on load. These will be populated if they were previously set
             apiKeyBox.Text = apiKey;
             subDomainBox.Text = subdomain;
+            tournamentNameBox.Text = tournamentName;
         }
 
         public String getAPIKey()
@@ -37,11 +39,17 @@ namespace SkillKeeper
             return subDomainBox.Text;
         }
 
+        public String getTournamentName()
+        {
+            return tournamentName;
+        }
+
         private void authButton_Click(object sender, EventArgs e)
         {
             //Store api key and subdomain inputs for use if import form is closed and re-opened
             apiKey = apiKeyBox.Text;
             subdomain = subDomainBox.Text;
+            tournamentName = tournamentNameBox.Text;
 
             this.Close();
         }

--- a/SkillKeeper/SkillKeeper.Designer.cs
+++ b/SkillKeeper/SkillKeeper.Designer.cs
@@ -1085,7 +1085,7 @@
             this.player1DataGridViewTextBoxColumn.HeaderText = "Player1";
             this.player1DataGridViewTextBoxColumn.Name = "player1DataGridViewTextBoxColumn";
             this.player1DataGridViewTextBoxColumn.ReadOnly = true;
-            this.player1DataGridViewTextBoxColumn.Width = 65;
+            this.player1DataGridViewTextBoxColumn.Width = 67;
             // 
             // player2DataGridViewTextBoxColumn
             // 
@@ -1094,7 +1094,7 @@
             this.player2DataGridViewTextBoxColumn.HeaderText = "Player2";
             this.player2DataGridViewTextBoxColumn.Name = "player2DataGridViewTextBoxColumn";
             this.player2DataGridViewTextBoxColumn.ReadOnly = true;
-            this.player2DataGridViewTextBoxColumn.Width = 65;
+            this.player2DataGridViewTextBoxColumn.Width = 67;
             // 
             // winnerDataGridViewTextBoxColumn
             // 
@@ -1102,7 +1102,7 @@
             this.winnerDataGridViewTextBoxColumn.DataPropertyName = "Winner";
             this.winnerDataGridViewTextBoxColumn.HeaderText = "Winner";
             this.winnerDataGridViewTextBoxColumn.Name = "winnerDataGridViewTextBoxColumn";
-            this.winnerDataGridViewTextBoxColumn.Width = 64;
+            this.winnerDataGridViewTextBoxColumn.Width = 66;
             // 
             // descriptionDataGridViewTextBoxColumn
             // 
@@ -1110,7 +1110,7 @@
             this.descriptionDataGridViewTextBoxColumn.DataPropertyName = "Description";
             this.descriptionDataGridViewTextBoxColumn.HeaderText = "Description";
             this.descriptionDataGridViewTextBoxColumn.Name = "descriptionDataGridViewTextBoxColumn";
-            this.descriptionDataGridViewTextBoxColumn.Width = 83;
+            this.descriptionDataGridViewTextBoxColumn.Width = 85;
             // 
             // Column1
             // 
@@ -1119,7 +1119,7 @@
             this.Column1.HeaderText = "Date";
             this.Column1.Name = "Column1";
             this.Column1.ReadOnly = true;
-            this.Column1.Width = 53;
+            this.Column1.Width = 55;
             // 
             // orderDataGridViewTextBoxColumn
             // 
@@ -1127,7 +1127,7 @@
             this.orderDataGridViewTextBoxColumn.DataPropertyName = "Order";
             this.orderDataGridViewTextBoxColumn.HeaderText = "Order";
             this.orderDataGridViewTextBoxColumn.Name = "orderDataGridViewTextBoxColumn";
-            this.orderDataGridViewTextBoxColumn.Width = 56;
+            this.orderDataGridViewTextBoxColumn.Width = 58;
             // 
             // matchBindingSource
             // 
@@ -1207,7 +1207,7 @@
             this.dataGridViewTextBoxColumn2.HeaderText = "Team";
             this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
             this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.Width = 57;
+            this.dataGridViewTextBoxColumn2.Width = 59;
             // 
             // dataGridViewTextBoxColumn1
             // 
@@ -1216,7 +1216,7 @@
             this.dataGridViewTextBoxColumn1.HeaderText = "Name";
             this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
             this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.Width = 58;
+            this.dataGridViewTextBoxColumn1.Width = 60;
             // 
             // dataGridViewTextBoxColumn3
             // 
@@ -1225,7 +1225,7 @@
             this.dataGridViewTextBoxColumn3.HeaderText = "Characters";
             this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
             this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.Width = 81;
+            this.dataGridViewTextBoxColumn3.Width = 83;
             // 
             // dataGridViewTextBoxColumn4
             // 
@@ -1234,7 +1234,7 @@
             this.dataGridViewTextBoxColumn4.HeaderText = "Wins";
             this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
             this.dataGridViewTextBoxColumn4.ReadOnly = true;
-            this.dataGridViewTextBoxColumn4.Width = 54;
+            this.dataGridViewTextBoxColumn4.Width = 56;
             // 
             // dataGridViewTextBoxColumn5
             // 
@@ -1243,7 +1243,7 @@
             this.dataGridViewTextBoxColumn5.HeaderText = "Losses";
             this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
             this.dataGridViewTextBoxColumn5.ReadOnly = true;
-            this.dataGridViewTextBoxColumn5.Width = 63;
+            this.dataGridViewTextBoxColumn5.Width = 65;
             // 
             // dataGridViewTextBoxColumn6
             // 
@@ -1252,7 +1252,7 @@
             this.dataGridViewTextBoxColumn6.HeaderText = "Draws";
             this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
             this.dataGridViewTextBoxColumn6.ReadOnly = true;
-            this.dataGridViewTextBoxColumn6.Width = 60;
+            this.dataGridViewTextBoxColumn6.Width = 62;
             // 
             // totalGamesDataGridViewTextBoxColumn
             // 
@@ -1261,7 +1261,7 @@
             this.totalGamesDataGridViewTextBoxColumn.HeaderText = "Total Played";
             this.totalGamesDataGridViewTextBoxColumn.Name = "totalGamesDataGridViewTextBoxColumn";
             this.totalGamesDataGridViewTextBoxColumn.ReadOnly = true;
-            this.totalGamesDataGridViewTextBoxColumn.Width = 89;
+            this.totalGamesDataGridViewTextBoxColumn.Width = 91;
             // 
             // winPercentDataGridViewTextBoxColumn
             // 
@@ -1270,7 +1270,7 @@
             this.winPercentDataGridViewTextBoxColumn.HeaderText = "Win %";
             this.winPercentDataGridViewTextBoxColumn.Name = "winPercentDataGridViewTextBoxColumn";
             this.winPercentDataGridViewTextBoxColumn.ReadOnly = true;
-            this.winPercentDataGridViewTextBoxColumn.Width = 60;
+            this.winPercentDataGridViewTextBoxColumn.Width = 62;
             // 
             // dataGridViewTextBoxColumn7
             // 
@@ -1279,7 +1279,7 @@
             this.dataGridViewTextBoxColumn7.HeaderText = "Score";
             this.dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
             this.dataGridViewTextBoxColumn7.ReadOnly = true;
-            this.dataGridViewTextBoxColumn7.Width = 58;
+            this.dataGridViewTextBoxColumn7.Width = 60;
             // 
             // LastMatch
             // 
@@ -1288,7 +1288,7 @@
             this.LastMatch.HeaderText = "Last Match";
             this.LastMatch.Name = "LastMatch";
             this.LastMatch.ReadOnly = true;
-            this.LastMatch.Width = 83;
+            this.LastMatch.Width = 85;
             // 
             // personBindingSource
             // 
@@ -1498,7 +1498,7 @@
             this.label32.Name = "label32";
             this.label32.Size = new System.Drawing.Size(107, 13);
             this.label32.TabIndex = 4;
-            this.label32.Text = "v1.0.1.4 (2/11/2015)";
+            this.label32.Text = "v1.0.1.5 (11/4/2015)";
             // 
             // pictureBox1
             // 

--- a/SkillKeeper/SkillKeeper.cs
+++ b/SkillKeeper/SkillKeeper.cs
@@ -619,7 +619,8 @@ namespace SkillKeeper
 
                 try
                 {
-                    importer.importChallonge(skChallongeLoader.getAPIKey(), skChallongeLoader.getSubDomain(), playerList);
+                    importer.importChallonge(skChallongeLoader.getAPIKey(), skChallongeLoader.getSubDomain(), 
+                                             skChallongeLoader.getTournamentName(), playerList);
                 }
                 catch (ChallongeApiException ex)
                 {

--- a/SkillKeeper/SkillKeeper.resx
+++ b/SkillKeeper/SkillKeeper.resx
@@ -2150,7 +2150,7 @@
 </value>
   </data>
   <data name="textBox1.Text" xml:space="preserve">
-    <value>v1.0.1.4 (2/11/2015)
+    <value>v1.0.1.5 (11/4/2015) (emb) - Added Challonge import without subdomain or owner's api key. v1.0.1.4 (2/11/2015)
 - Fixed issue with unfinished tournament import in Challonge (now uses create date if completion date does not exist).
 - Adjusted player import selection detection.
 


### PR DESCRIPTION
Added a field for tournament name to Challonge Loader. Providing the
tournament name/id will allow user to import a challonge bracket that is
neither associated with the provided api key nor part of any subdomain.

ChallongeImporter's import method now takes an extra argument for
tournament name. If provided, that tournament will be looked up and added
to the list of possible imports.

In the ChallongeApiWrapper, the ShowTournament method now takes a string
instead of an int. The int gets cast into a string anyway, and the
tournament name or id can be used. ShowTournament also now handles the
case where a subdomain and tournament name are both provided. The
Tournament class has a slight modification, it now has a specified equals
behavior (using full url), so that duplicates aren't added to the list if
name of a tournament is specified along with its subdomain or associated
api key.