### PR TITLE
Stopgap for Smash.gg Import function

### DIFF
--- a/SmashGGApiWrapper/Tournament.cs
+++ b/SmashGGApiWrapper/Tournament.cs
@@ -50,7 +50,7 @@ namespace SmashGGApiWrapper
         public string venueAddress { get; set; }
         public string region { get; set; }
         public string hashtag { get; set; }
-        public bool showCity { get; set; }
+        public object showCity { get; set; }
         public int attendeeLocationInfo { get; set; }
         public int attendeeContactInfo { get; set; }
         //public AttendeeFieldConfig attendeeFieldConfig { get; set; }

--- a/SmashGGApiWrapper/Videogame.cs
+++ b/SmashGGApiWrapper/Videogame.cs
@@ -10,7 +10,7 @@ namespace SmashGGApiWrapper
         public string displayName { get; set; }
         public int minPerEntry { get; set; }
         public int maxPerEntry { get; set; }
-        public bool enabled { get; set; }
+        public object enabled { get; set; }
         public string slug { get; set; }
         public object isCardGame { get; set; }
         public object characterTerm { get; set; }


### PR DESCRIPTION
According to Smashboards user Demandatwin, these are the offending properties: https://smashboards.com/threads/skillkeeper-trueskill%E2%84%A2-rankings-bookkeeper.376590/page-8#post-21741867. While Demandatwin changed the bool to string to fix the importing on his local repo, ThreeFold changes the bool to object to fix the errors in deserializing the JSON to bool. Went with ThreeFold's way since he's more likely to contribute to this project. Might just need to change all bool properties if we're not using the JSON.NET package to deserialize. But since the smash.gg API will probably change again and break things, this is just a stopgap.